### PR TITLE
Add options for mongoose and removed redundant await

### DIFF
--- a/commands/MakeModel.js
+++ b/commands/MakeModel.js
@@ -82,6 +82,14 @@ class MakeMongoose extends Command {
     const validatorPath = path.join(this.Helpers.appRoot(), relativePath)
 
     /**
+     * Split and pop to get the actual model name, only needs
+     * to be full for pathing
+     * 
+     * eg: adonis make:mongoose Directory/Model
+     */
+    name = name.split('/').pop()
+
+    /**
      * If command is not executed via command line, then return
      * the response
      */

--- a/instructions.md
+++ b/instructions.md
@@ -35,6 +35,9 @@ Finally add the database config inside `config/database.js` file.
       username: Env.get('MONGO_USER', 'admin'),
       password: Env.get('MONGO_PASSWORD', ''),
       database: Env.get('MONGO_DATABASE', 'adonis'),
+      options: {
+        // All options can be found at http://mongoosejs.com/docs/connections.html
+      }
     }
   },
 ```
@@ -153,7 +156,7 @@ This is an example of a Token Model compatible with the Mongoose Serializer
      * @memberof Token
      */
     static async fetchSession(token, type) {
-      return await this.findOneAndUpdate({
+      return this.findOneAndUpdate({
         token,
         type,
         expires: {

--- a/providers/MongooseProvider.js
+++ b/providers/MongooseProvider.js
@@ -27,13 +27,14 @@ class MongooseProvider extends ServiceProvider {
   async _registerMongoose() {
     this.app.singleton('Adonis/Addons/Mongoose', function (app) {
       const Config = app.use('Adonis/Src/Config')
-      const { host, port, database, user, pass } = Config.get('database.mongodb.connection')
+      const { host, port, database, user, pass, options } = Config.get('database.mongodb.connection')
 
       const connectUri = `mongodb://${host}:${port}/${database}`
       const connectionString = (user || pass) ? `${user}:${pass}@${connectUri}` : connectUri
       Mongoose.Promise = global.Promise
       Mongoose.connect(connectionString, {
-        useMongoClient: true
+        useMongoClient: true,
+        ...options
       })
 
       return Mongoose


### PR DESCRIPTION
I'll leave the versioning for you to add, but having the options for Mongoose is pretty important, for people who'd like to set the authdb, disabling autoIndex, reconnect, poolSizes, etc.