### PR TITLE
Field convention default. snake_case to camelCase

### DIFF
--- a/src/Model/Base.js
+++ b/src/Model/Base.js
@@ -120,7 +120,7 @@ class BaseModel {
     options = { options, ...this.schemaOptions }
 
     if (this.timestamps !== false) {
-      options.timestamps = { createdAt: 'created_at', updatedAt: 'updated_at' }
+      options.timestamps = { createdAt: 'createdAt', updatedAt: 'updatedAt' }
     }
 
     this._schema = new Schema(this._getRawSchema(), options)


### PR DESCRIPTION
can we make this as default since most mongo users names their field in camel case.