### PR TITLE
enhacement: hidden passwords + trait & factory support

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -143,6 +143,32 @@ UserHook.notifyUpdate = async (modelInstance) => {
 
 The addHook functionality doesn't necesarely needs a hook. You can use a callback (the mongoose's middleware doc), and the name of the hook is composed by [pre | post] [Init | Save | Remove | Validate]. It's important that the command is written in CamelCase.
 
+## Using traits
+
+Traits work exactly the same way they do in Adonisjs, please refer to the official [Adonis traits documentation](https://adonisjs.com/docs/4.1/traits). Traits are initialized in the boot method:
+
+```
+  static boot ({ schema }) {
+    this.addTrait('App/Models/Traits/HasMedia', { // trait options })
+  }
+```
+
+It's worth noting that everty trait has access to the schema property on the model, accessible through the `Model._schema()` property. This enabled us to alter the schema from the trait.
+
+```
+class HasMedia {
+  register (Model, customOptions = {}) {
+    const defaultOptions = {}
+    const options = Object.assign(defaultOptions, customOptions)
+    
+     // add a new field to the schema
+    Model._schema.add({ my_media: String })
+      
+    Model.prototype.testFunction = async function(){
+      console.log("this function will be available from the model")
+    }
+```
+
 ## Using timestamps
 
 As default, adonis-mongoose-model comes with the created_at and updated_at property, that comes with a middleware that updates the updated_at prop each time you save.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adonis-mongoose-model",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Model/Base.js
+++ b/src/Model/Base.js
@@ -1,11 +1,12 @@
 /* global use */
 'use strict'
 
-require('@adonisjs/fold')
+const fold = require('@adonisjs/fold')
 
 const mongoose = use('Adonis/Addons/Mongoose')
 const { Schema } = mongoose
 const utils = require('../utils')
+const GE = require('@adonisjs/generic-exceptions')
 
 class BaseModel {
   /**
@@ -64,7 +65,8 @@ class BaseModel {
      * If trait is a string, then point to register function
      */
     trait = typeof (trait) === 'string' ? `${trait}.register` : trait
-    const { method } = iocResolver.forDir('modelTraits').resolveFunc(trait)
+    // eslint-disable-line
+    const { method } = fold.resolver.forDir('modelTraits').resolveFunc(trait)
     method(this, options)
   }
 
@@ -190,7 +192,7 @@ class BaseModel {
    * @return {void}
    */
   merge (attributes) {
-    for (let key of Object.keys(attributes)) {
+    for (const key of Object.keys(attributes)) {
       this.set(key, attributes[key])
     }
   }

--- a/src/Model/Base.js
+++ b/src/Model/Base.js
@@ -164,6 +164,38 @@ class BaseModel {
   }
 
   /**
+   * Set attributes on model instance in bulk.
+   *
+   * NOTE: Calling this method will remove the existing attributes.
+   *
+   * @method fill
+   *
+   * @param  {Object} attributes
+   *
+   * @return {void}
+   */
+  fill (attributes) {
+    this.$attributes = {}
+    this.merge(attributes)
+  }
+
+  /**
+   * Merge attributes into on a model instance without
+   * overriding existing attributes and their values
+   *
+   * @method fill
+   *
+   * @param  {Object} attributes
+   *
+   * @return {void}
+   */
+  merge (attributes) {
+    for (let key of Object.keys(attributes)) {
+      this.set(key, attributes[key])
+    }
+  }
+
+  /**
    * Returns a created mongoose model, named like the name parameter.
    * It takes the
    *

--- a/src/Serializers/MongooseSerializer.js
+++ b/src/Serializers/MongooseSerializer.js
@@ -101,7 +101,7 @@ class MongooseSerializer {
     return this._Model
       .findOne({
         [this._config.uid || this.primaryKey]: uid
-      })
+      }).select('+password')
   }
 
   /**


### PR DESCRIPTION
The provider `auth` helpers will now work even if the password is set to `select: false` in the `User` schema.